### PR TITLE
Now filteres by cat and adds rider data in

### DIFF
--- a/veganuary.py
+++ b/veganuary.py
@@ -56,18 +56,42 @@ class CalculateResults:
         if (self.results_input_data):
             all_results = json.loads(self.results_input_data)["data"]
             for result in all_results:
-                if result["label"] == "1":
-                    if self.validate_result(result, "a"):
-                        self.stage_results["a"].append(result)
-                elif result["label"] == "2":
-                    if self.validate_result(result, "b"):
-                        self.stage_results["b"].append(result)
-                elif result["label"] == "3":
-                    if self.validate_result(result, "c"):
-                        self.stage_results["c"].append(result)
-                elif result["label"] == "4":
-                    if self.validate_result(result, "d"):
-                        self.stage_results["d"].append(result)
+                cat = self.get_cat_from_label(result["label"])
+                if self.validate_result(result, cat):
+                    filtered_result = self.get_filtered_result_data(result)
+                    result_with_rider_data = self.add_registered_data_to_result(filtered_result)
+                    self.stage_results[cat].append(result_with_rider_data)
+
+    def get_filtered_result_data(self, result):
+        filtered_result = {
+            "zp_name": result["name"],
+            "zid": result["DT_RowId"],
+            "category": self.get_cat_from_label(result["label"]),
+            "race_time": result["race_time"],
+            "time_diff": result["time_diff"]
+        }
+        return filtered_result
+
+    def add_registered_data_to_result(self, result):
+        # add rider info to result info
+        cat = result["category"]
+        for rider in self.riders[cat]:
+            if rider["zid"] == result["zid"]:
+                result["registered_name"] = rider["name"]
+                result["team"] = rider["team"],
+                result["subteam"] = rider["subteam"]
+            return result
+
+    def get_cat_from_label(self, label):
+        if label == "1":
+            return "a"
+        if label == "2":
+            return "b"
+        if label == "3":
+            return "c"
+        if label == "4":
+            return "d"
+        return ""
 
     def get_registered_zids(self, riders):
         # returns a list of registered zids
@@ -79,15 +103,21 @@ class CalculateResults:
 
     def validate_result(self, result, cat):
         # checks if this result is from a registered rider in the correct category
+        # if dq_cat is not empty, rider has been DQ'd
+        if result["dq_cat"] != "":
+            return False
         registered_zids = self.registered_zids[cat]
         if result["DT_RowId"] in registered_zids:
             return True
         return False
 
-    def get_veganuary_results(self, category):
+    def get_veganuary_stage_results(self, category):
         # attempt to create a csv from results
-        keys = stage_results[category].keys()
-        with open('veganuary_stage_results.csv', 'w', newline='')  as output_file:
-            dict_writer = csv.DictWriter(output_file, keys)
-            dict_writer.writeheader()
-            dict_writer.writerows(toCSV)
+        data = self.stage_results[category]
+        print (data)
+        # keys = data[0].keys()
+        #
+        # with open('veganuary_stage_results.csv', 'w', newline='')  as output_file:
+        #     dict_writer = csv.DictWriter(output_file, keys)
+        #     dict_writer.writeheader()
+        #     dict_writer.writerows(data)

--- a/veganuary_stage_results.csv
+++ b/veganuary_stage_results.csv
@@ -1,0 +1,3 @@
+name,zid,category
+D. uncan (OTR Haze),2124922,a
+GTR  GRINGO [nopinzR3R],1157845,a


### PR DESCRIPTION
Now successfully filters riders and provides:
 - only registered in results
 - filters out UPG/HR/WKG results etc.
 - adds data requested by chris - rider name, zp name, zwift ID, cat, team name, subteam name, race time, and time diff